### PR TITLE
Allow larger emlog devices

### DIFF
--- a/emlog.c
+++ b/emlog.c
@@ -82,7 +82,7 @@ static bool emlog_debug;
 
 static dev_t emlog_dev_type = 0;
 #define EMLOG_MINOR_BASE    1
-#define EMLOG_MINOR_COUNT   127 /* keep in sync with EMLOG_MAX_SIZE */
+#define EMLOG_MINOR_COUNT   (EMLOG_MAX_SIZE - 1)
 static struct cdev *emlog_cdev = NULL;
 static struct class *emlog_class = NULL;
 static struct device *emlog_dev_reg;
@@ -461,7 +461,7 @@ static int __init emlog_init(void)
         ret_val = -4; goto emlog_init_error;
     }
 
-    emlog_dev_reg = device_create(emlog_class, NULL, emlog_dev_type, NULL, DEVICE_NAME);
+    emlog_dev_reg = device_create(emlog_class, NULL, MKDEV(MAJOR(emlog_dev_type), 256), NULL, DEVICE_NAME, 256);
     if (emlog_dev_reg == NULL) {
         pr_err("Can not device_create.\n");
         ret_val = -5; goto emlog_init_error;

--- a/emlog.h
+++ b/emlog.h
@@ -21,7 +21,7 @@
  * $Id: emlog.h,v 1.6 2001/08/13 21:29:20 jelson Exp $
  */
 
-#define EMLOG_MAX_SIZE       128        /* max size in kilobytes of a buffer */
+#define EMLOG_MAX_SIZE       1024        /* max size in kilobytes of a buffer */
 #define DEVICE_NAME "emlog"
 
 #define EMLOG_VERSION        "0.60"

--- a/mkemlog.c
+++ b/mkemlog.c
@@ -45,8 +45,8 @@ int main(int argc, char** argv) {
         if (end_of_number == number) {
             error(1, 0, "Invalid size provided\n" USAGE);
         }
-        if (size_of_buffer < 1 || size_of_buffer > 128 ) {
-            error(1, 0, "Invalid size provided must be a value between 1 and 128\n" USAGE);
+        if (size_of_buffer < 1 || size_of_buffer > EMLOG_MAX_SIZE ) {
+            error(1, 0, "Invalid size provided must be a value between 1 and " EMLOG_MAX_SIZE "\n" USAGE);
         }
     }
     if (argc > 3 ) {


### PR DESCRIPTION
* change the default size of /dev/emlog from 1KB to 256KB
* allow emlog devices to be up to 1MB large