### PR TITLE
Add dkms support.

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,7 @@
+PACKAGE_NAME="emlog"
+PACKAGE_VERSION="0.70"
+AUTOINSTALL="yes"
+CLEAN="make clean"
+BUILT_MODULE_NAME[0]="emlog"
+DEST_MODULE_NAME[0]="emlog"
+DEST_MODULE_LOCATION[0]="/extra/emlog"


### PR DESCRIPTION
Hi, I have added dkms.conf to automatically update the driver on kernel update.

In addition, this can be added to the Makefile (dkms needs to know the version).

```
DKMS = dkms

dkms_install: VERSION = $(shell grep 'PACKAGE_VERSION' dkms.conf | grep -oEe '[0-9.]+')
dkms_install:
   $(DKMS) add .
   $(DKMS) install emlog/$(VERSION)

dkms_remove: VERSION = $(shell grep 'PACKAGE_VERSION' dkms.conf | grep -oEe '[0-9.]+')
dkms_remove:
   $(DKMS) remove emlog/$(VERSION) --all
   rm -rf /usr/src/emlog-$(VERSION)
```