### PR TITLE
emlog: Do not use no_llseek with kernel 6.12.0+

### DIFF
--- a/emlog.c
+++ b/emlog.c
@@ -464,7 +464,12 @@ static const struct file_operations emlog_fops = {
     .open = emlog_open,
     .release = emlog_release,
     .poll = emlog_poll,
-    .llseek = no_llseek,        /* no_llseek by default introduced at v2.6.37-rc1 */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+    /* no_llseek by default introduced at v2.6.37-rc1 and
+     * removed in 6.12.0
+     */
+    .llseek = no_llseek,
+#endif
     .owner = THIS_MODULE,
 };
 


### PR DESCRIPTION
no_llseek is finally gone with 6.12-rc1 [1]

[1] https://github.com/torvalds/linux/commit/cb787f4ac0c2e439ea8d7e6387b925f74576bdf8